### PR TITLE
Filter out past events from event list

### DIFF
--- a/packages/ilmomasiina-backend/src/routes/events/getEventsList.ts
+++ b/packages/ilmomasiina-backend/src/routes/events/getEventsList.ts
@@ -55,13 +55,15 @@ export async function getEventsListForUser(
     order: eventOrder(),
   });
 
-  const res = events.map((event) => ({
-    ...stringifyDates(event.get({ plain: true })),
-    quotas: event.quotas!.map((quota) => ({
-      ...quota.get({ plain: true }),
-      signupCount: Number(quota.signupCount!),
-    })),
-  }));
+  const res = events
+    .filter((event) => event.endDate === null || new Date(event.endDate) >= new Date())
+    .map((event) => ({
+      ...stringifyDates(event.get({ plain: true })),
+      quotas: event.quotas!.map((quota) => ({
+        ...quota.get({ plain: true }),
+        signupCount: Number(quota.signupCount!),
+      })),
+    }));
 
   reply.status(200);
   return res;


### PR DESCRIPTION
Add a simple filter to not show past events to users. This solves https://github.com/fyysikkokilta/ilmomasiina/issues/20.