### PR TITLE
fix slow serving of static files by precompressing them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage:
-FROM node:14-alpine as builder
-
+FROM node:16-alpine as builder
+RUN apk add --no-cache brotli
 # Build-time env variables
 
 # Copy source files
@@ -26,6 +26,10 @@ ENV NODE_ENV=production
 
 # Build all packages
 RUN npm run build
+
+# precompress static files for frontend
+RUN find packages/ilmomasiina-frontend/build -type f\
+  -regex ".*\.\(js\|json\|html\|map\|css\|svg\|ico\|txt\)" -exec gzip -k "{}" \; -exec brotli "{}" \;
 
 # Main stage:
 FROM node:16-alpine

--- a/packages/ilmomasiina-backend/src/app.ts
+++ b/packages/ilmomasiina-backend/src/app.ts
@@ -52,17 +52,10 @@ export default async function initApp(): Promise<FastifyInstance> {
     }
   }
 
-  // Add on-the-fly compression
-  server.register(fastifyCompress, { inflateIfDeflated: true });
-
-  server.register(setupRoutes, {
-    prefix: '/api',
-    adminSession: new AdminAuthSession(config.feathersAuthSecret),
-  });
-
   // Serving frontend files if frontendFilesPath is not null.
   // Ideally these files should be served by a web server and not the app server,
   // but this helps run a low-effort server.
+  // frontend files should not be gzipped on the fly, rather done on the build step.
   if (config.frontendFilesPath) {
     console.info(`Serving frontend files from '${config.frontendFilesPath}'`);
     // With fastify-static, historyApiFallback mode works out of the box
@@ -75,6 +68,13 @@ export default async function initApp(): Promise<FastifyInstance> {
       reply.sendFile('index.html');
     });
   }
+  // Add on-the-fly compression
+  server.register(fastifyCompress, { inflateIfDeflated: true });
+
+  server.register(setupRoutes, {
+    prefix: '/api',
+    adminSession: new AdminAuthSession(config.feathersAuthSecret),
+  });
 
   // Every minute, remove signups that haven't been confirmed fast enough
   cron.schedule('* * * * *', deleteUnconfirmedSignups);


### PR DESCRIPTION
Currently the setup is that all static frontend files are gzip/broli compressed on request, which causes major CPU usage and slowness for the first load. This PR fixes this by not trying to compress any of the static files from the frontend directory on the fly, but they are rather compressed during the docker build step.
## comparison of loading the main bundle:
Before:
<img width="271" alt="image" src="https://github.com/fyysikkokilta/ilmomasiina/assets/71292737/6726810e-d795-4a30-b76b-19d5ac837dca">
After:
<img width="231" alt="image" src="https://github.com/fyysikkokilta/ilmomasiina/assets/71292737/9028d0be-2a92-470c-9f1d-9b5cdb929c76">

Edit: to be clear I'm not 100% if this works OOB for you as you seem to have a bit different of a build than us, but this gives you and idea at least.